### PR TITLE
Bump parsec version requirements

### DIFF
--- a/irc.cabal
+++ b/irc.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 library
   ghc-options:     -Wall
-  build-depends:   base == 4.*, parsec == 2.1.*
+  build-depends:   base == 4.*, parsec >= 2.1 && < 3.2
   exposed-Modules: Network.IRC,
                    Network.IRC.Base,
                    Network.IRC.Commands,


### PR DESCRIPTION
Hopefully fixes build issues with the ircbot package which depends on hsirc.
