### PR TITLE
One or more spaces between arguments

### DIFF
--- a/Network/IRC/Parser.hs
+++ b/Network/IRC/Parser.hs
@@ -146,7 +146,7 @@ message :: Parser Message
 message  = Message <$>
       optionMaybe (tokenize prefix)
   <*> command
-  <*> many (spaces *> parameter)
+  <*> many (some spaces *> parameter)
   <*  optional crlf
   <*  endOfInput
   <?> "message"


### PR DESCRIPTION
More than one space between arguments causes empty parameters. Fixed.